### PR TITLE
移除仓库内的赞助链接

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-custom: ['https://www.xtreme.net.cn/donate']


### PR DESCRIPTION
GitHub会自动使用组织README仓库的赞助文件,所以不需要担心